### PR TITLE
Multinode support based on UBF, batch implementation

### DIFF
--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -131,6 +131,7 @@ from .test_unbounded_foreach_decorator import (
     InternalTestUnboundedForeachDecorator,
     InternalTestUnboundedForeachInput,
 )
+from .multinode_decorator import MultinodeDecorator
 from .conda.conda_step_decorator import CondaStepDecorator
 
 STEP_DECORATORS = _merge_lists(
@@ -145,6 +146,7 @@ STEP_DECORATORS = _merge_lists(
         StepFunctionsInternalDecorator,
         CondaStepDecorator,
         InternalTestUnboundedForeachDecorator,
+        MultinodeDecorator,
     ],
     _ext_plugins.STEP_DECORATORS,
     "name",

--- a/metaflow/plugins/aws/batch/batch_client.py
+++ b/metaflow/plugins/aws/batch/batch_client.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict, deque
+import copy
 import random
 import select
 import sys
@@ -94,6 +95,50 @@ class BatchJob(object):
                 self._max_swap,
                 self._swappiness,
             )
+
+        # Multinode
+        if getattr(self, "_nodes", 0) > 1:
+            num_nodes = self._nodes
+            main_task_override = copy.deepcopy(self.payload["containerOverrides"])
+            # TERRIBLE HACK JUST TO TRY THIS WORKS
+
+            # main
+            commands = self.payload["containerOverrides"]["command"][-1]
+            # add split-index as this worker is also an ubf_task
+            commands = commands.replace("[multinode-args]", "--split-index 0")
+            main_task_override["command"][-1] = commands
+
+            # secondary tasks
+            secondary_task_container_override = copy.deepcopy(
+                self.payload["containerOverrides"]
+            )
+            secondary_commands = self.payload["containerOverrides"]["command"][-1]
+            # other tasks do not have control- prefix, and have the split id appended to the task -id
+            secondary_commands = secondary_commands.replace(
+                self._task_id,
+                self._task_id.replace("control-", "")
+                + "-node-$AWS_BATCH_JOB_NODE_INDEX",
+            )
+            secondary_commands = secondary_commands.replace(
+                "ubf_control",
+                "ubf_task",
+            )
+            secondary_commands = secondary_commands.replace(
+                "[multinode-args]", "--split-index $AWS_BATCH_JOB_NODE_INDEX"
+            )
+
+            secondary_task_container_override["command"][-1] = secondary_commands
+            self.payload["nodeOverrides"] = {
+                "nodePropertyOverrides": [
+                    {"targetNodes": "0:0", "containerOverrides": main_task_override},
+                    {
+                        "targetNodes": "1:{}".format(num_nodes - 1),
+                        "containerOverrides": secondary_task_container_override,
+                    },
+                ],
+            }
+            del self.payload["containerOverrides"]
+
         response = self._client.submit_job(**self.payload)
         job = RunningJob(response["jobId"], self._client)
         return job.update()
@@ -108,6 +153,7 @@ class BatchJob(object):
         max_swap,
         swappiness,
         host_volumes,
+        nodes,
     ):
         # identify platform from any compute environment associated with the
         # queue
@@ -146,6 +192,8 @@ class BatchJob(object):
         }
 
         if platform == "FARGATE" or platform == "FARGATE_SPOT":
+            if nodes > 1:
+                raise BatchJobException("Fargate does not support multinode jobs.")
             if execution_role is None:
                 raise BatchJobException(
                     "No AWS Fargate task execution IAM role found. Please see "
@@ -215,6 +263,25 @@ class BatchJob(object):
                     {"sourceVolume": name, "containerPath": host_path}
                 )
 
+        nodes = int(nodes)
+        if nodes > 1:
+            job_definition["type"] = "multinode"
+            job_definition["nodeProperties"] = {"numNodes": nodes, "mainNode": 0}
+            job_definition["nodeProperties"]["nodeRangeProperties"] = [
+                {
+                    "targetNodes": "0:0",  # The properties are same for main node and others,
+                    # but as we use nodeOverrides later for main and others
+                    # differently, also the job definition must match those patterns
+                    "container": job_definition["containerProperties"],
+                },
+                {
+                    "targetNodes": "1:{}".format(nodes - 1),
+                    "container": job_definition["containerProperties"],
+                },
+            ]
+            del job_definition["containerProperties"]  # not used for multi-node
+            self._nodes = nodes
+
         # check if job definition already exists
         def_name = (
             "metaflow_%s"
@@ -252,6 +319,7 @@ class BatchJob(object):
         max_swap,
         swappiness,
         host_volumes,
+        nodes,
     ):
         self.payload["jobDefinition"] = self._register_job_definition(
             image,
@@ -262,6 +330,7 @@ class BatchJob(object):
             max_swap,
             swappiness,
             host_volumes,
+            nodes,
         )
         return self
 
@@ -275,6 +344,10 @@ class BatchJob(object):
 
     def image(self, image):
         self._image = image
+        return self
+
+    def task_id(self, task_id):
+        self._task_id = task_id
         return self
 
     def iam_role(self, iam_role):
@@ -505,13 +578,22 @@ class RunningJob(object):
 
     @property
     def reason(self):
-        return self.info["container"].get("reason")
+        if "container" in self.info:
+            # single-node job
+            return self.info["container"].get("reason")
+        else:
+            # multinode
+            return self.info["statusReason"]
 
     @property
     def status_code(self):
         if not self.is_done:
             self.update()
-        return self.info["container"].get("exitCode")
+        if "container" in self.info:
+            return self.info["container"].get("exitCode")
+        else:
+            # multinode
+            return self.info["attempts"][-1]["container"].get("exitCode")
 
     def kill(self):
         if not self.is_done:

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -2,9 +2,10 @@ import os
 import sys
 import platform
 import requests
+import time
 
 from metaflow import util
-from metaflow import R
+from metaflow import R, current
 
 from metaflow.decorators import StepDecorator
 from metaflow.plugins import ResourcesDecorator
@@ -20,6 +21,7 @@ from metaflow.metaflow_config import (
     DATASTORE_LOCAL_DIR,
 )
 from metaflow.sidecar import SidecarSubProcess
+from metaflow.unbounded_foreach import UBF_CONTROL
 
 from .batch import BatchException
 from ..aws_utils import get_docker_registry
@@ -96,6 +98,7 @@ class BatchDecorator(StepDecorator):
         "max_swap": None,
         "swappiness": None,
         "host_volumes": None,
+        "nodes": 1,
     }
     package_url = None
     package_sha = None
@@ -150,7 +153,10 @@ class BatchDecorator(StepDecorator):
                     my_val = self.attributes.get(k)
                     if not (my_val is None and v is None):
                         self.attributes[k] = str(max(int(my_val or 0), int(v or 0)))
-
+            elif (
+                deco.__class__.__name__ == "MultinodeDecorator"
+            ):  # avoid circular dependency
+                self.attributes["nodes"] = deco.nodes
         # Set run time limit for the AWS Batch job.
         self.run_time_limit = get_run_time_limit_for_task(decos)
         if self.run_time_limit < 60:
@@ -249,6 +255,24 @@ class BatchDecorator(StepDecorator):
 
             self._save_logs_sidecar = SidecarSubProcess("save_logs_periodically")
 
+        nodes = self.attributes["nodes"]
+
+        if nodes > 1 and ubf_context == UBF_CONTROL:
+            # UBF handling for multinode case
+            control_task_id = current.task_id
+            top_task_id = control_task_id.replace("control-", "")  # chop "-0"
+            mapper_task_ids = [control_task_id] + [
+                "%s-node-%d" % (top_task_id, node_idx) for node_idx in range(1, nodes)
+            ]
+            flow._control_mapper_tasks = [
+                "%s/%s/%s" % (run_id, step_name, mapper_task_id)
+                for mapper_task_id in mapper_task_ids
+            ]
+            flow._control_task_is_mapper_zero = True
+
+        if nodes > 1:
+            _set_multinode_environment()
+
     def task_post_step(
         self, step_name, flow, graph, retry_count, max_user_code_retries
     ):
@@ -292,9 +316,68 @@ class BatchDecorator(StepDecorator):
             # Best effort kill
             pass
 
+        if is_task_ok and getattr(flow, "_control_mapper_tasks", []):
+            self._wait_for_mapper_tasks(flow, step_name)
+
+    def _wait_for_mapper_tasks(self, flow, step_name):
+        """
+        When lauching multinode task with UBF, need to wait for the secondary
+        tasks to finish cleanly and produce their output before exiting the
+        main task. Otherwise main task finishing will cause secondary nodes
+        to terminate immediately, and possibly prematurely.
+        """
+        from metaflow import Step  # avoid circular dependency
+
+        t = time.time()
+        TIMEOUT = 600
+        print("Waiting for batch secondary tasks to finish")
+        while t + TIMEOUT > time.time():
+            time.sleep(2)
+            try:
+                step_path = "%s/%s/%s" % (flow.name, current.run_id, step_name)
+                tasks = [task for task in Step(step_path)]
+                if len(tasks) == len(flow._control_mapper_tasks) - 1:
+                    if all(
+                        task.finished_at is not None for task in tasks
+                    ):  # for some reason task.finished fails
+                        return True
+                else:
+                    print(
+                        "Not sufficient number of tasks:",
+                        len(tasks),
+                        len(flow._control_mapper_tasks),
+                    )
+            except Exception as e:
+                print(e)
+                pass
+        raise Exception(
+            "Batch secondary workers did not finish in %s seconds" % TIMEOUT
+        )
+
     @classmethod
     def _save_package_once(cls, flow_datastore, package):
         if cls.package_url is None:
             cls.package_url, cls.package_sha = flow_datastore.save_data(
                 [package.blob], len_hint=1
             )[0]
+
+
+def _set_multinode_environment():
+    # setup the multinode environment
+    import socket
+
+    if "AWS_BATCH_JOB_MAIN_NODE_PRIVATE_IPV4_ADDRESS" not in os.environ:
+        # we are the main node
+        local_ips = socket.gethostbyname_ex(socket.gethostname())[-1]
+        assert local_ips, "Could not find local ip address"
+        os.environ["MF_MULTINODE_MAIN_IP"] = local_ips[0]
+    else:
+        os.environ["MF_MULTINODE_MAIN_IP"] = os.environ[
+            "AWS_BATCH_JOB_MAIN_NODE_PRIVATE_IPV4_ADDRESS"
+        ]
+    os.environ["MF_MULTINODE_NUM_NODES"] = os.environ["AWS_BATCH_JOB_NUM_NODES"]
+    os.environ["MF_MULTINODE_NODE_INDEX"] = os.environ["AWS_BATCH_JOB_NODE_INDEX"]
+    print(
+        "Multinode environment:",
+        {k: v for k, v in os.environ.items() if k.startswith("MF_MULTINODE")},
+    )

--- a/metaflow/plugins/multinode_decorator.py
+++ b/metaflow/plugins/multinode_decorator.py
@@ -1,0 +1,13 @@
+from metaflow.decorators import StepDecorator
+from metaflow.unbounded_foreach import UnboundedForeachInput
+
+
+class MultinodeDecorator(StepDecorator):
+    name = "multinode"
+    defaults = {
+        "nodes": 2,
+    }
+
+    def __init__(self, attributes=None, statically_defined=False):
+        self.nodes = attributes["nodes"]
+        super(MultinodeDecorator, self).__init__(attributes, statically_defined)

--- a/metaflow/runtime.py
+++ b/metaflow/runtime.py
@@ -364,6 +364,11 @@ class NativeRuntime(object):
             top = foreach_stack[-1]
             bottom = list(foreach_stack[:-1])
             s = tuple(bottom + [top._replace(index=None)])
+
+            # UBF control can also be the first task of the list. Then
+            # it will have index=0 instead of index=None.
+            if task.results.get("_control_task_is_mapper_zero", False):
+                s = tuple(bottom + [top._replace(index=0)])
             control_path = self._finished.get((task.step, s))
             if control_path:
                 # Control task was successful.
@@ -374,7 +379,6 @@ class NativeRuntime(object):
                 for i in range(num_splits):
                     s = tuple(bottom + [top._replace(index=i)])
                     required_tasks.append(self._finished.get((task.step, s)))
-                required_tasks.append(control_path)
 
                 if all(required_tasks):
                     # all tasks to be joined are ready. Schedule the next join step.

--- a/metaflow/task.py
+++ b/metaflow/task.py
@@ -345,14 +345,6 @@ class MetaflowTask(object):
         output.init_task()
 
         if input_paths:
-            control_paths = [
-                path
-                for path in input_paths
-                if path.split("/")[-1].startswith("control-")
-            ]
-            if control_paths:
-                [control_path] = control_paths
-                input_paths.remove(control_path)
             # 2. initialize input datastores
             inputs = self._init_data(run_id, join_type, input_paths)
 


### PR DESCRIPTION
This PR enables running multinode jobs with AWS Batch, and in the future other runtimes.

The usage is simple, and follows UBF, but omitting the actual "foreach=xx" in the self.next. Instead, user defines a @multinode decorator. The UBF is applied behind the scenes by injecting a special multinode UBF attribute.

```
@step
def train_start(self):
    self.next(self.train)

@multinode(nodes=4) 
@batch
@step
def train(self):
    ...
    ...
    self.next(self.train_end)

@step 
def train_end(self, inputs):
    ....
```

Environment variables such as "MF_MULTINODE_MAIN_IP_ADDRESS" are set to enable workers to find  each other. Users should not use this environment variables but instead use helpers provided by us, such as PyTorch helper (not in this PR).

Since the PR contains two separate parts in two different commits:  (1) core changes; (2) batch change, it might be easier to review the commits separately. Or, I can make separate PRs as well.


